### PR TITLE
removed unnecessary page criteria

### DIFF
--- a/chapter1/T1.2a/pageTransition1.json
+++ b/chapter1/T1.2a/pageTransition1.json
@@ -15,7 +15,7 @@
       "exerciseCriteria": "correctInput",
       "mailCriteria": null,
       "affectedExercise": "chapter1/T1.2a/textExercise1.json",
-      "affectedPage": null",
+      "affectedPage": null,
       "affectedMail": null
     }
   ]

--- a/chapter1/T1.2a/pageTransition1.json
+++ b/chapter1/T1.2a/pageTransition1.json
@@ -11,11 +11,11 @@
   },
   "criteria": [
     {
-      "pageCriteria": "visited",
+      "pageCriteria": null,
       "exerciseCriteria": "correctInput",
       "mailCriteria": null,
       "affectedExercise": "chapter1/T1.2a/textExercise1.json",
-      "affectedPage": "chapter1/T1.2a/page.json",
+      "affectedPage": null,
       "affectedMail": null
     }
   ]

--- a/chapter1/T1.2a/pageTransition1.json
+++ b/chapter1/T1.2a/pageTransition1.json
@@ -11,11 +11,11 @@
   },
   "criteria": [
     {
-      "pageCriteria": "visited",
+      "pageCriteria": null,
       "exerciseCriteria": "correctInput",
       "mailCriteria": null,
       "affectedExercise": "chapter1/T1.2a/textExercise1.json",
-      "affectedPage": "chapter1/T1.2a/page.json",
+      "affectedPage": null",
       "affectedMail": null
     }
   ]


### PR DESCRIPTION
I believe that when you are still on a page (T1.2a), the game can't register that you have "visited" it. It only registered visited pages once you have tranbsitioned out of them. I therefore remove the additional page criteria "visited" from this transition.